### PR TITLE
fix phpstan not detecting WP_CLI::error() function will stop code execution

### DIFF
--- a/wp-cli-stubs.php
+++ b/wp-cli-stubs.php
@@ -4583,6 +4583,8 @@ namespace {
          * @param string|WP_Error|Exception|Throwable $message Message to write to STDERR.
          * @param boolean|integer            $exit    True defaults to exit(1).
          * @return null
+         * 
+         * @phpstan-return ($exit is true|positive-int ? never : void)
          */
         public static function error($message, $exit = \true)
         {


### PR DESCRIPTION
Because the return type of the WP_CLI::error function is currently defined as `null`, PHPStan assumes code execution never stops when calling `WP_CLI::error()`. And code following phpstan assumes will still be executed.

For example:

```
$post = get_post( 1 );
if ( ! $post instanceof \WP_Post ) {
    WP_CLI::error( 'Post does not exist' );
}

// Here PHPStan thinks $post can still be something else than a \WP_Post, and will show appropriate error that the `post_type` property does not always exist on $post.
$post_type = $post->post_type;
WP_CLI::success( sprintf( 'The post type is %s', $post_type ) );
```

To solve this, i've looked at the [original WP_CLI repo code for WP_CLI::error()](https://github.com/wp-cli/wp-cli/blob/main/php/class-wp-cli.php#L915C5-L915C64), and put the @phpstan-return docblock line from there in the subs as well.
```
@phpstan-return ($exit is true|positive-int ? never : void)
```