### PR TITLE
Adjust `php-stubs/wordpress-stubs` dependency range so 7.0 can be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "homepage": "https://github.com/php-stubs/wp-cli-stubs",
     "license": "MIT",
     "require": {
-        "php-stubs/wordpress-stubs": "^4.7 || >=5.0"
+        "php-stubs/wordpress-stubs": ">=4.7"
     },
     "require-dev": {
         "php": "~7.3 || ~8.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "homepage": "https://github.com/php-stubs/wp-cli-stubs",
     "license": "MIT",
     "require": {
-        "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0"
+        "php-stubs/wordpress-stubs": "^4.7 || >=5.0"
     },
     "require-dev": {
         "php": "~7.3 || ~8.0",


### PR DESCRIPTION
Allows this to be used alongside the latest WordPress stubs. 

```bash
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires php-stubs/wp-cli-stubs ^2.12 -> satisfiable by php-stubs/wp-cli-stubs[v2.12.0].
    - php-stubs/wp-cli-stubs v2.12.0 requires php-stubs/wordpress-stubs ^4.7 || ^5.0 || ^6.0 -> found php-stubs/wordpress-stubs[v4.7.14, ..., v4.9.20, v5.0, ..., v5.9.9, v6.0.0, ..., v6.9.4] but it conflicts with your root composer.json require (~7.0
```

Opted for `>=` from https://github.com/szepeviktor/phpstan-wordpress/pull/307 , instead of appending ` || ^7.0`